### PR TITLE
Update Confirmo gateway and settings for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contributors: confirmoadm
 Tags: Confirmo, Cryptocurrency, Crypto, Crypto Payments, Payment Gateway  
 Requires at least: 6.2  
 Tested up to: 6.7  
-Stable tag: 2.7.0
+Stable tag: 2.8.0
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stable tag: 2.8.2
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
-Crypto payments made easy with with industry leaders. Confirmo.net
+Crypto payments made easy with with industry leaders. Confirmo.com
 
 == Description ==
 
@@ -70,7 +70,7 @@ Verification is usually done within one business day. This means that an account
 
 We currently support the following cryptocurrencies: BTC, BTC (Lightning), ETH, SOL, LTC, TRX, USDC and USDT.
 
-Would you like to see another cryptocurrency here? Contact us at support@confirmo.net
+Would you like to see another cryptocurrency here? Contact us at support@confirmo.com
 
 
 = How does Confirmo guarantee the exchange rate when I accept crypto but receive fiat?

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contributors: confirmoadm
 Tags: Confirmo, Cryptocurrency, Crypto, Crypto Payments, Payment Gateway  
 Requires at least: 6.2  
 Tested up to: 6.7  
-Stable tag: 2.8.1
+Stable tag: 2.8.2
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
@@ -18,7 +18,7 @@ Start accepting cryptocurrency payments with Confirmo, one of the fastest growin
 
 By accepting crypto payments you open your business to a new revenue stream. Despite being commonly viewed as an investment tool, cryptocurrencies were created as an alternative to centralized, inflationary financial systems, and crypto holders are now looking for businesses which accept their funds. Using Confirmo's WooCommerce plugin is a simple way to do so. Installing it is quick and easy, so choose your preferred method below.
 
-> This plugin connects your WooCommerce instance with the 3rd-party service Confirmo. More information about the Confirmo crypto payment gateway can be found at [https://confirmo.net](https://confirmo.net). An integral part of the plugin is the API requests to Confirmo, which are described in more detail in [the Confirmo API documentation](https://confirmo.net/docs/api-reference).
+> This plugin connects your WooCommerce instance with the 3rd-party service Confirmo. More information about the Confirmo crypto payment gateway can be found at [https://confirmo.com](https://confirmo.com). An integral part of the plugin is the API requests to Confirmo, which are described in more detail in [the Confirmo API documentation](https://confirmo.com/docs/api-reference).
 
 
 ## Installing the plugin
@@ -40,13 +40,13 @@ By accepting crypto payments you open your business to a new revenue stream. Des
 4. In your Wordpress dashboard, go to WooCommerce – Settings – Payments. Click Confirmo. You will be asked to configure the plugin with information generated in your Confirmo account to connect them.
 
 ## Connecting the plugin to your Confirmo account:
-Create an account at [https://confirmo.net](https://confirmo.net) and then go to `Settings – API Keys – Create API key`. You will be required to complete an e-mail verification, after which you will receive the API key. Once you have it, go to `WooCommerce – Settings – Payments`, and enable Confirmo as a payment method. Paste the API key into the respective field.
+Create an account at [https://confirmo.com](https://confirmo.com) and then go to `Settings – API Keys – Create API key`. You will be required to complete an e-mail verification, after which you will receive the API key. Once you have it, go to `WooCommerce – Settings – Payments`, and enable Confirmo as a payment method. Paste the API key into the respective field.
 
 To generate a callback password, return to the Confirmo dashboard and go to `Settings – Callback password`. You will be prompted to complete a second e-mail verification and then provided with the callback password. Again, paste it into the respective field in `WooCommerce – Settings – Payments`. Callback passwords help increase the security of the API integration. Never share your API key or callback password with anyone!
 
 Finally, choose your desired Settlement currency. Make sure to save your changes by clicking the button at the bottom. When the plugin is activated, Confirmo will appear as a payment option in your website's WooCommerce checkout. **Congratulations, you can now start receiving cryptocurrency payments!**
 
-Read more at [Confirmo.net](https://confirmo.net). Should you encounter any difficulties, [contact us](mailto:support@confirmo.net) at [support@confirmo.net](mailto:support@confirmo.net).
+Read more at [Confirmo.com](https://confirmo.com). Should you encounter any difficulties, [contact us](mailto:support@confirmo.com) at [support@confirmo.com](mailto:support@confirmo.com).
 
 
 == Frequently Asked Questions ==
@@ -96,4 +96,4 @@ Settlements (recurrent withdrawals) are free, but bank fees apply.
 
 = Where can I find the Terms & Conditions? =
 
-The most up-to-date Terms & Conditions are available on the Confirmo website in [the Terms & Conditions](https://confirmo.net/legal/terms-and-conditions) section.
+The most up-to-date Terms & Conditions are available on the Confirmo website in [the Terms & Conditions](https://confirmo.com/legal/terms-and-conditions) section.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stable tag: 2.8.2
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
-Crypto payments made easy with with industry leaders. Confirmo.com
+Crypto payments made easy with industry leaders. Confirmo.com
 
 == Description ==
 

--- a/confirmo-payment-gateway.php
+++ b/confirmo-payment-gateway.php
@@ -4,7 +4,7 @@
 * Description: Accept payments in Bitcoin, Ethereum, USDT, USDC, and more directly in WooCommerce. Fast, secure, and easy-to-use crypto payment gateway.
 * Version: 2.8.2
 * Requires PHP: 7.4
-* Author: Confirmo.net
+* Author: Confirmo.com
 * Author URI: https://confirmo.com
 * Text Domain: confirmo-for-woocommerce
 * Domain Path: /languages

--- a/confirmo-payment-gateway.php
+++ b/confirmo-payment-gateway.php
@@ -2,10 +2,10 @@
 /*
 * Plugin Name: Confirmo Cryptocurrency Payment Gateway for WooCommerce
 * Description: Accept payments in Bitcoin, Ethereum, USDT, USDC, and more directly in WooCommerce. Fast, secure, and easy-to-use crypto payment gateway.
-* Version: 2.8.1
+* Version: 2.8.2
 * Requires PHP: 7.4
 * Author: Confirmo.net
-* Author URI: https://confirmo.net
+* Author URI: https://confirmo.com
 * Text Domain: confirmo-for-woocommerce
 * Domain Path: /languages
 * Requires Plugins: woocommerce

--- a/confirmo-payment-gateway.php
+++ b/confirmo-payment-gateway.php
@@ -16,6 +16,10 @@
 global $confirmo_version;
 $confirmo_version = '2.8.2';
 
+if (!defined('CONFIRMO_API_URL')) {
+    define('CONFIRMO_API_URL', 'https://api.confirmo.com');
+}
+
 if (!defined('ABSPATH')) exit;
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/WC_Confirmo_Activator.php';

--- a/confirmo-payment-gateway.php
+++ b/confirmo-payment-gateway.php
@@ -14,7 +14,7 @@
 */
 
 global $confirmo_version;
-$confirmo_version = '2.8.1';
+$confirmo_version = '2.8.2';
 
 if (!defined('ABSPATH')) exit;
 

--- a/includes/WC_Confirmo_Activator.php
+++ b/includes/WC_Confirmo_Activator.php
@@ -26,6 +26,7 @@ class WC_Confirmo_Activator
             'custom_states' => [
                 'prepared' => 'on-hold',
                 'active' => 'on-hold',
+                'pending_verification' => 'on-hold',
                 'confirming' => 'on-hold',
                 'paid' => 'completed',
                 'expired' => 'failed',

--- a/includes/WC_Confirmo_Activator.php
+++ b/includes/WC_Confirmo_Activator.php
@@ -70,7 +70,11 @@ class WC_Confirmo_Activator
         dbDelta($sql);
 
         add_option('confirmo_version', $confirmo_version);
-        add_option('confirmo_base_url', 'https://confirmo.net');
+        add_option('confirmo_base_url', 'https://confirmo.com');
+
+        if (get_option('confirmo_base_url') === 'https://confirmo.net') {
+            update_option('confirmo_base_url', 'https://confirmo.com');
+        }
     }
 
     /**

--- a/includes/WC_Confirmo_Activator.php
+++ b/includes/WC_Confirmo_Activator.php
@@ -70,11 +70,6 @@ class WC_Confirmo_Activator
         dbDelta($sql);
 
         update_option('confirmo_version', $confirmo_version);
-        add_option('confirmo_base_url', 'https://confirmo.com');
-
-        if (get_option('confirmo_base_url') === 'https://confirmo.net') {
-            update_option('confirmo_base_url', 'https://confirmo.com');
-        }
     }
 
     /**

--- a/includes/WC_Confirmo_Activator.php
+++ b/includes/WC_Confirmo_Activator.php
@@ -69,7 +69,7 @@ class WC_Confirmo_Activator
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta($sql);
 
-        add_option('confirmo_version', $confirmo_version);
+        update_option('confirmo_version', $confirmo_version);
         add_option('confirmo_base_url', 'https://confirmo.com');
 
         if (get_option('confirmo_base_url') === 'https://confirmo.net') {

--- a/includes/WC_Confirmo_Gateway.php
+++ b/includes/WC_Confirmo_Gateway.php
@@ -661,7 +661,7 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
         }
 
         $customer_profile = [
-            'profileId' => $order->get_customer_id(),
+            'profileId' => $order->get_customer_email(),
             'type' => $order->get_billing_company() ? 'company' : 'individual',
             'streetAddress' => $order->get_billing_address_1(),
             'city' => $order->get_billing_city(),

--- a/includes/WC_Confirmo_Gateway.php
+++ b/includes/WC_Confirmo_Gateway.php
@@ -661,7 +661,7 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
         }
 
         $customer_profile = [
-            'profileId' => $order->get_customer_email(),
+            'profileId' => $order->get_billing_email(),
             'type' => $order->get_billing_company() ? 'company' : 'individual',
             'streetAddress' => $order->get_billing_address_1(),
             'city' => $order->get_billing_city(),

--- a/includes/WC_Confirmo_Gateway.php
+++ b/includes/WC_Confirmo_Gateway.php
@@ -866,6 +866,9 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
             case 'confirming':
                 $message = __('Payment received, awaiting confirmations', 'confirmo-for-woocommerce');
                 break;
+            case 'pending_verification':
+                $message = __('Client needs to provide additional info to satisfy regulatory requirements.', 'confirmo-for-woocommerce');
+                break;
             case 'paid':
                 $message = __('Payment confirmed, letting woocommerce decide whether to complete order or set to processing', 'confirmo-for-woocommerce');
                 break;
@@ -880,10 +883,19 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
                 return;
         }
 
+        /**
+         * If the Confirmo status is 'completed' or 'processing', mark the payment as complete in WooCommerce.
+         * This changes order status internally and triggers related actions, such as confirming stock reduction.
+         */
         if ($values[$confirmo_status] === 'completed' || $values[$confirmo_status] === 'processing') {
             $order->payment_complete();
         }
 
+        /**
+         * Update the order status in WooCommerce based on the mapping defined in plugin settings. 
+         * This ensures that the order status is in sync with the user defined mapping for each Confirmo status.
+         * Although this is reduntant in our default mapping of statuses, it allows for custom mappings defined by the user.
+         */
         $changed = $order->update_status($values[$confirmo_status], $message);
     
         if (!$changed) {

--- a/includes/WC_Confirmo_Gateway.php
+++ b/includes/WC_Confirmo_Gateway.php
@@ -864,14 +864,14 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
 
         if ($values[$confirmo_status] === 'completed' || $values[$confirmo_status] === 'processing') {
             $order->payment_complete();
-        } else {
-            $changed = $order->update_status($values[$confirmo_status], $message);
-
-            if (!$changed) {
-                $this->addDebugLog($order->get_id(), __('Order update status failed', 'confirmo-for-woocommerce'), 'order_status_update');
-            }
         }
 
+        $changed = $order->update_status($values[$confirmo_status], $message);
+    
+        if (!$changed) {
+            $this->addDebugLog($order->get_id(), __('Order update status failed', 'confirmo-for-woocommerce'), 'order_status_update');
+        }
+        
         $this->addDebugLog($order->get_id(), "Order status updated to: " . $order->get_status() . " based on Confirmo status: " . $confirmo_status, 'order_status_update');
     }
 

--- a/includes/WC_Confirmo_Gateway.php
+++ b/includes/WC_Confirmo_Gateway.php
@@ -127,7 +127,7 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
     {
         global $confirmo_version;
 
-        if (get_site_option('confirmo_version') != $confirmo_version) {
+        if (get_option('confirmo_version') != $confirmo_version) {
             WC_Confirmo_Activator::activate();
         }
     }

--- a/includes/WC_Confirmo_Gateway.php
+++ b/includes/WC_Confirmo_Gateway.php
@@ -21,7 +21,6 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
     protected $wpdb;
     public string $pluginName;
     public string $pluginBaseDir;
-    private string $apiBaseUrl;
     public static array $allowedCurrencies = [
         'USDT' => 'USDT',
         'USDC' => 'USDC',
@@ -59,7 +58,6 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
         $this->apiKey = get_option('confirmo_gate_config_options')['api_key'];
         $this->settlementCurrency = get_option('confirmo_gate_config_options')['settlement_currency'];
         $this->callbackPassword = get_option('confirmo_gate_config_options')['callback_password'];
-        $this->apiBaseUrl = 'https://api.confirmo.com';
         // If needed, other initializations can be done here.
     }
 
@@ -280,9 +278,9 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
 
         $wpdb->query(
             $wpdb->prepare(
-                "DELETE FROM %i WHERE time < %d",
+                "DELETE FROM %i WHERE time < %s",
                 $table_name,
-                strtotime('-30 days', current_time('timestamp'))
+                date('Y-m-d H:i:s', strtotime('-30 days'))
             )
         );
     }
@@ -626,7 +624,6 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
      */
     public function process_payment($order_id): array
     {
-        global $woocommerce;
         global $confirmo_version;
 
         $order = wc_get_order($order_id);
@@ -644,7 +641,7 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
         $product_description = rtrim($product_description, ' + ');
         $customer_email = $order->get_billing_email();
 
-        $url = $this->apiBaseUrl . '/api/v3/invoices';
+        $url = CONFIRMO_API_URL . '/api/v3/invoices';
 
         $notify_url = $this->generateNotifyUrl();
         $return_url = $order->get_checkout_order_received_url();
@@ -717,7 +714,7 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
         $order->update_status('pending', __('Awaiting Confirmo payment.', 'confirmo-for-woocommerce'));
 
         wc_reduce_stock_levels($order_id);
-        $woocommerce->cart->empty_cart();
+        WC()->cart->empty_cart();
 
         if ($order_id && $response_data) {
             $this->addDebugLog($order_id, wp_json_encode($response_data), $confirmo_redirect_url);
@@ -820,7 +817,7 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
     private function verifyInvoiceStatus($invoice_id)
     {
         $api_key = $this->apiKey;
-        $url = $this->apiBaseUrl . '/api/v3/invoices/' . $invoice_id;
+        $url = CONFIRMO_API_URL . '/api/v3/invoices/' . $invoice_id;
 
         $response = wp_remote_get($url, [
             'headers' => [
@@ -957,7 +954,8 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
     {
         $notification_url = home_url('confirmo-notification');
         $return_url = wc_get_cart_url();
-        $url = $this->apiBaseUrl . '/api/v3/invoices';
+        $url = CONFIRMO_API_URL . '/api/v3/invoices';
+
 
         $data = [
             'settlement' => ['currency' => $currency],

--- a/includes/WC_Confirmo_Gateway.php
+++ b/includes/WC_Confirmo_Gateway.php
@@ -59,7 +59,7 @@ class WC_Confirmo_Gateway extends WC_Payment_Gateway
         $this->apiKey = get_option('confirmo_gate_config_options')['api_key'];
         $this->settlementCurrency = get_option('confirmo_gate_config_options')['settlement_currency'];
         $this->callbackPassword = get_option('confirmo_gate_config_options')['callback_password'];
-        $this->apiBaseUrl = get_option('confirmo_base_url');
+        $this->apiBaseUrl = 'https://api.confirmo.com';
         // If needed, other initializations can be done here.
     }
 

--- a/includes/WC_Confirmo_Settings.php
+++ b/includes/WC_Confirmo_Settings.php
@@ -181,7 +181,7 @@ class WC_Confirmo_Settings
             'prepared' => 'on-hold',
             'active' => 'on-hold',
             'confirming' => 'on-hold',
-            'paid' => 'complete',
+            'paid' => 'completed',
             'expired' => 'failed',
             'error' => 'failed',
         ];

--- a/includes/WC_Confirmo_Settings.php
+++ b/includes/WC_Confirmo_Settings.php
@@ -110,7 +110,13 @@ class WC_Confirmo_Settings
                 'status' => 'Confirming',
                 'desc' => 'Payment has been detected, and the amount is correct or higher, but it is still awaiting sufficient confirmations on the crypto network.',
                 'next_label' => 'Next states:',
-                'next_value' => 'Error, Paid'
+                'next_value' => 'Error, Paid, Pending Verification'
+            ],
+            [
+                'status' => 'Pending Verification',
+                'desc' => 'Client needs to provide additional info to satisfy regulatory requirements.',
+                'next_label' => 'Next states:',
+                'next_value' => 'Expired, Paid'
             ],
             [
                 'status' => 'Error',
@@ -181,6 +187,7 @@ class WC_Confirmo_Settings
             'prepared' => 'on-hold',
             'active' => 'on-hold',
             'confirming' => 'on-hold',
+            'pending_verification' => 'on-hold',
             'paid' => 'completed',
             'expired' => 'failed',
             'error' => 'failed',

--- a/includes/WC_Confirmo_Settings.php
+++ b/includes/WC_Confirmo_Settings.php
@@ -68,7 +68,7 @@ class WC_Confirmo_Settings
 
     public static function configSectionCallback(): void
     {
-        echo '<p>' . esc_html__('Adjust the settings for Confirmo payment gateway. For detailed installation guidance, refer to the ', 'confirmo-for-woocommerce') . '<a href="https://confirmo.com/blog/how-to-accept-crypto-with-woocommerce/" target="_blank">' . esc_html__('Confirmo installation guide', 'confirmo-for-woocommerce') . '</a></p>';
+        echo '<p>' . esc_html__('Adjust the settings for Confirmo payment gateway. For detailed installation guidance, refer to the ', 'confirmo-for-woocommerce') . '<a href="https://docs.confirmo.com/docs/woocommerce-plugin" target="_blank">' . esc_html__('Confirmo installation guide', 'confirmo-for-woocommerce') . '</a></p>';
     }
 
     public static function configAdvancedCallback(): void
@@ -170,7 +170,7 @@ class WC_Confirmo_Settings
         }
         echo '</select>';
 
-        echo '<p style="font-size: 13px;max-width: 500px; margin-top: 10px;">' . esc_html__('The currency in which funds will be credited and held in your account. If you select  \'Crypto Settlement (In Kind),\' all payments will be retained in the cryptocurrency used by the customer during checkout (e.g., BTC, ETH). Withdrawals will always be made in the settlement currency, whether fiat or cryptocurrency. It is not possible to exchange or convert settlement currencies for withdrawals. Funds must be withdrawn in the same currency in which they are settled. You need to set the settlement currency in our administration in order to be able to withdraw funds. More information is available ', 'confirmo-for-woocommerce') . '<a href="https://confirmo.com/blog/how-to-accept-crypto-with-woocommerce/#aioseo-">' . esc_html__('here', 'confirmo-for-woocommerce') . '</a></p>';
+        echo '<p style="font-size: 13px;max-width: 500px; margin-top: 10px;">' . esc_html__('The currency in which funds will be credited and held in your account. If you select  \'Crypto Settlement (In Kind),\' all payments will be retained in the cryptocurrency used by the customer during checkout (e.g., BTC, ETH). Withdrawals will always be made in the settlement currency, whether fiat or cryptocurrency. It is not possible to exchange or convert settlement currencies for withdrawals. Funds must be withdrawn in the same currency in which they are settled. You need to set the settlement currency in our administration in order to be able to withdraw funds. More information is available ', 'confirmo-for-woocommerce') . '<a href="https://docs.confirmo.com/docs/woocommerce-plugin">' . esc_html__('here', 'confirmo-for-woocommerce') . '</a></p>';
     }
 
     public static function configDescriptionCallback(): void

--- a/includes/WC_Confirmo_Settings.php
+++ b/includes/WC_Confirmo_Settings.php
@@ -238,7 +238,7 @@ class WC_Confirmo_Settings
             $api_key = sanitize_text_field($input['api_key']);
             $new_input['api_key'] = $api_key;
 
-            $url = 'https://confirmo.com/api/v3/currencies';
+            $url = 'https://api.confirmo.com/api/v3/currencies';
 
             $response = wp_remote_get($url, [
                 'headers' => [

--- a/includes/WC_Confirmo_Settings.php
+++ b/includes/WC_Confirmo_Settings.php
@@ -238,7 +238,7 @@ class WC_Confirmo_Settings
             $api_key = sanitize_text_field($input['api_key']);
             $new_input['api_key'] = $api_key;
 
-            $url = 'https://api.confirmo.com/api/v3/currencies';
+            $url = CONFIRMO_API_URL . '/api/v3/currencies';
 
             $response = wp_remote_get($url, [
                 'headers' => [

--- a/includes/WC_Confirmo_Settings.php
+++ b/includes/WC_Confirmo_Settings.php
@@ -238,7 +238,7 @@ class WC_Confirmo_Settings
             $api_key = sanitize_text_field($input['api_key']);
             $new_input['api_key'] = $api_key;
 
-            $url =  'https://confirmo.net/api/v3/currencies';
+            $url = 'https://confirmo.com/api/v3/currencies';
 
             $response = wp_remote_get($url, [
                 'headers' => [

--- a/includes/WC_Confirmo_Settings.php
+++ b/includes/WC_Confirmo_Settings.php
@@ -68,7 +68,7 @@ class WC_Confirmo_Settings
 
     public static function configSectionCallback(): void
     {
-        echo '<p>' . esc_html__('Adjust the settings for Confirmo payment gateway. For detailed installation guidance, refer to the ', 'confirmo-for-woocommerce') . '<a href="https://confirmo.net/blog/how-to-accept-crypto-with-woocommerce/" target="_blank">' . esc_html__('Confirmo installation guide', 'confirmo-for-woocommerce') . '</a></p>';
+        echo '<p>' . esc_html__('Adjust the settings for Confirmo payment gateway. For detailed installation guidance, refer to the ', 'confirmo-for-woocommerce') . '<a href="https://confirmo.com/blog/how-to-accept-crypto-with-woocommerce/" target="_blank">' . esc_html__('Confirmo installation guide', 'confirmo-for-woocommerce') . '</a></p>';
     }
 
     public static function configAdvancedCallback(): void
@@ -170,7 +170,7 @@ class WC_Confirmo_Settings
         }
         echo '</select>';
 
-        echo '<p style="font-size: 13px;max-width: 500px; margin-top: 10px;">' . esc_html__('The currency in which funds will be credited and held in your account. If you select  \'Crypto Settlement (In Kind),\' all payments will be retained in the cryptocurrency used by the customer during checkout (e.g., BTC, ETH). Withdrawals will always be made in the settlement currency, whether fiat or cryptocurrency. It is not possible to exchange or convert settlement currencies for withdrawals. Funds must be withdrawn in the same currency in which they are settled. You need to set the settlement currency in our administration in order to be able to withdraw funds. More information is available ', 'confirmo-for-woocommerce') . '<a href="https://confirmo.net/blog/how-to-accept-crypto-with-woocommerce/#aioseo-">' . esc_html__('here', 'confirmo-for-woocommerce') . '</a></p>';
+        echo '<p style="font-size: 13px;max-width: 500px; margin-top: 10px;">' . esc_html__('The currency in which funds will be credited and held in your account. If you select  \'Crypto Settlement (In Kind),\' all payments will be retained in the cryptocurrency used by the customer during checkout (e.g., BTC, ETH). Withdrawals will always be made in the settlement currency, whether fiat or cryptocurrency. It is not possible to exchange or convert settlement currencies for withdrawals. Funds must be withdrawn in the same currency in which they are settled. You need to set the settlement currency in our administration in order to be able to withdraw funds. More information is available ', 'confirmo-for-woocommerce') . '<a href="https://confirmo.com/blog/how-to-accept-crypto-with-woocommerce/#aioseo-">' . esc_html__('here', 'confirmo-for-woocommerce') . '</a></p>';
     }
 
     public static function configDescriptionCallback(): void

--- a/languages/confirmo-payment-gateway.pot
+++ b/languages/confirmo-payment-gateway.pot
@@ -164,7 +164,7 @@ msgid "Confirmo Payment URL:"
 msgstr ""
 
 #. Author of the plugin
-msgid "Confirmo.net"
+msgid "Confirmo.com"
 msgstr ""
 
 #: confirmo-payment-gateway.php:504 confirmo-payment-gateway.php:712
@@ -179,7 +179,7 @@ msgstr ""
 
 #: confirmo-payment-gateway.php:505 confirmo-payment-gateway.php:713
 msgid ""
-"Create an account at <a href=\"https://confirmo.net\">Confirmo.net</a> and "
+"Create an account at <a href=\"https://confirmo.com\">Confirmo.com</a> and "
 "then go to Settings – API Keys – Create API key. You will be required to "
 "complete an e-mail verification, after which you will receive the API key. "
 "Once you have it, go to WooCommerce – Settings – Payments, and enable "
@@ -195,7 +195,7 @@ msgid "Crypto payments made easy with industry leaders."
 msgstr ""
 
 #: confirmo-payment-gateway.php:476 confirmo-payment-gateway.php:684
-msgid "Crypto payments made easy with industry leaders. Confirmo.net"
+msgid "Crypto payments made easy with industry leaders. Confirmo.com"
 msgstr ""
 
 #: confirmo-payment-gateway.php:539
@@ -281,7 +281,7 @@ msgid "Generating a payment button using shortcode"
 msgstr ""
 
 #. Author URI of the plugin
-msgid "https://confirmo.net"
+msgid "https://confirmo.com"
 msgstr ""
 
 #: confirmo-payment-gateway.php:603
@@ -375,9 +375,9 @@ msgstr ""
 
 #: confirmo-payment-gateway.php:511 confirmo-payment-gateway.php:731
 msgid ""
-"Read more at <a href=\"https://confirmo.net\">Confirmo.net</a>. Should you "
-"encounter any difficulties, <a href=\"mailto:support@confirmo.net\">contact "
-"us</a> at support@confirmo.net"
+"Read more at <a href=\"https://confirmo.com\">Confirmo.com</a>. Should you "
+"encounter any difficulties, <a href=\"mailto:support@confirmo.com\">contact "
+"us</a> at support@confirmo.com"
 msgstr ""
 
 #: confirmo-payment-gateway.php:159


### PR DESCRIPTION
- hardcoded production API base URL, now defined in one place as const - for dev purposes it's easily replaceable, eliminating need for using WP options mechanism
- fix for wrong condition for purging logs older than 30 days
- WooCommerce convention fix, eliminating call using $woocommerce global, using core setter instead